### PR TITLE
Cleaned up import of commander module and its use

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ function sitesInfo(options) {
     }
   }
   if (options.sites) {
+    console.log(options.sites)
     sites = sites.concat(options.sites)
   }
   return sites.map(createIterableSiteObject);

--- a/run.js
+++ b/run.js
@@ -1,15 +1,17 @@
 #!/usr/bin/env node
 'use strict'
 
-import commander from 'commander'
+import { Command } from 'commander/esm.mjs';
 import execute from './index.js'
 
-commander
-  .option('-s, --sites [sites]', 'a comma delimited list of site urls to analyze with Lighthouse', (str) => str.split(','), [])
+const program = new Command;
+
+program
+  .option('-s, --sites [sites...]', 'Space delimited list of site urls to analyze with Lighthouse', [])
   .option('-f, --file [path]', 'an input file with a site url per-line to analyze with Lighthouse')
   .option('-p, --params <params>', 'extra parameters to pass to lighthouse cli for each execution e.g. -p "--perf --quiet"')
   .option('-o, --out [out]', `the output folder to place reports, defaults to './report/lighthouse/'`)
   .option('-v, --verbose', 'enable verbose logging')
-  .parse(commander.argv)
+  .parse(program.argv)
 
-execute(commander.opts())
+execute(program.opts())


### PR DESCRIPTION
Changed the way the Commander module is imported to what is on the README for it.

Modified the sites option by using Commander's Variadic option instead of the passed custom function to split the sites into an array.